### PR TITLE
Log ADC values

### DIFF
--- a/grandpapa_board.X/main.c
+++ b/grandpapa_board.X/main.c
@@ -201,10 +201,10 @@ static void send_status_ok_mcp(void) {
     mcp_can_send(&board_stat_msg);
 }
 
-static void send_status_ok_mcp(void) {
+static void send_log_msgs(void) {
     can_msg_t batt_cur_msg;
     uint16_t batt_cur = ADCC_GetSingleConversion(channel_BATT_CURR)/2;
-    build_analog_data_msg(millis(), SENSOR_BATT_CURR, batt_curr, &batt_cur_msg);
+    build_analog_data_msg(millis(), SENSOR_BATT_CURR, batt_cur, &batt_cur_msg);
     txb_enqueue(&batt_cur_msg);
     
     can_msg_t batt_volt_msg;
@@ -214,7 +214,7 @@ static void send_status_ok_mcp(void) {
 
     can_msg_t aux_cur_msg;
     uint16_t aux_cur = ADCC_GetSingleConversion(channel_AUX_CURR)/2;
-    build_analog_data_msg(millis(), SENSOR_MAG_2, aux_curr, &aux_cur_msg);
+    build_analog_data_msg(millis(), SENSOR_MAG_2, aux_cur, &aux_cur_msg);
     txb_enqueue(&aux_cur_msg);
 }
 

--- a/grandpapa_board.X/mcc_generated_files/adcc.c
+++ b/grandpapa_board.X/mcc_generated_files/adcc.c
@@ -1,0 +1,299 @@
+/**
+  ADCC Generated Driver File
+
+  @Company
+    Microchip Technology Inc.
+
+  @File Name
+    adcc.c
+
+  @Summary
+    This is the generated driver implementation file for the ADCC driver using PIC10 / PIC12 / PIC16 / PIC18 MCUs
+
+  @Description
+    This source file provides implementations for driver APIs for ADCC.
+    Generation Information :
+        Product Revision  :  PIC10 / PIC12 / PIC16 / PIC18 MCUs - 1.65.2
+        Device            :  PIC18F26K83
+        Driver Version    :  2.01
+    The generated drivers are tested against the following:
+        Compiler          :  XC8 1.45
+        MPLAB             :  MPLAB X 4.15
+*/
+
+/*
+    (c) 2018 Microchip Technology Inc. and its subsidiaries. 
+    
+    Subject to your compliance with these terms, you may use Microchip software and any 
+    derivatives exclusively with Microchip products. It is your responsibility to comply with third party 
+    license terms applicable to your use of third party software (including open source software) that 
+    may accompany Microchip software.
+    
+    THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES, WHETHER 
+    EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE, INCLUDING ANY 
+    IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY, AND FITNESS 
+    FOR A PARTICULAR PURPOSE.
+    
+    IN NO EVENT WILL MICROCHIP BE LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, 
+    INCIDENTAL OR CONSEQUENTIAL LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND 
+    WHATSOEVER RELATED TO THE SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP 
+    HAS BEEN ADVISED OF THE POSSIBILITY OR THE DAMAGES ARE FORESEEABLE. TO 
+    THE FULLEST EXTENT ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL 
+    CLAIMS IN ANY WAY RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT 
+    OF FEES, IF ANY, THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS 
+    SOFTWARE.
+*/
+
+/**
+  Section: Included Files
+*/
+#include <xc.h>
+#include "adcc.h"
+
+/**
+  Section: ADCC Module Variables
+*/
+
+/**
+  Section: ADCC Module APIs
+*/
+
+void ADCC_Initialize(void)
+{
+    // set the ADCC to the options selected in the User Interface
+    // ADLTH 0; 
+    ADLTHL = 0x00;
+    // ADLTH 0; 
+    ADLTHH = 0x00;
+    // ADUTH 0; 
+    ADUTHL = 0x00;
+    // ADUTH 0; 
+    ADUTHH = 0x00;
+    // ADSTPT 0; 
+    ADSTPTL = 0x00;
+    // ADSTPT 0; 
+    ADSTPTH = 0x00;
+    // ADACC 0; 
+    ADACCU = 0x00;
+    // ADRPT 0; 
+    ADRPT = 0x00;
+    // ADPCH ANA0; 
+    ADPCH = 0x00;
+    // ADACQ 0; 
+    ADACQL = 0x00;
+    // ADACQ 0; 
+    ADACQH = 0x00;
+    // ADCAP Additional uC disabled; 
+    ADCAP = 0x00;
+    // ADPRE 0; 
+    ADPREL = 0x00;
+    // ADPRE 0; 
+    ADPREH = 0x00;
+    // ADDSEN disabled; ADGPOL digital_low; ADIPEN disabled; ADPPOL Vss; 
+    ADCON1 = 0x00;
+    // ADCRS 0; ADMD Basic_mode; ADACLR disabled; ADPSIS RES; 
+    ADCON2 = 0x00;
+    // ADCALC First derivative of Single measurement; ADTMD disabled; ADSOI ADGO not cleared; 
+    ADCON3 = 0x00;
+    // ADMATH registers not updated; 
+    ADSTAT = 0x00;
+    // ADNREF VSS; ADPREF FVR; 
+    ADREF = 0x03;
+    // ADACT disabled; 
+    ADACT = 0x00;
+    // ADCS FOSC/100; 
+    ADCLK = 0x31;
+    // ADGO stop; ADFM right; ADON enabled; ADCS FOSC/ADCLK; ADCONT disabled; 
+    ADCON0 = 0x84;
+}
+
+void ADCC_StartConversion(adcc_channel_t channel)
+{
+    // select the A/D channel
+    ADPCH = channel;      
+  
+    // Turn on the ADC module
+    ADCON0bits.ADON = 1;
+
+    // Start the conversion
+    ADCON0bits.ADGO = 1;
+}
+
+bool ADCC_IsConversionDone()
+{
+    // Start the conversion
+    return ((unsigned char)(!ADCON0bits.ADGO));
+}
+
+adc_result_t ADCC_GetConversionResult(void)
+{
+    // Return the result
+    return ((adc_result_t)((ADRESH << 8) + ADRESL));
+}
+
+adc_result_t ADCC_GetSingleConversion(adcc_channel_t channel)
+{
+    // select the A/D channel
+    ADPCH = channel;  
+
+    // Turn on the ADC module
+    ADCON0bits.ADON = 1;
+	
+    //Disable the continuous mode.
+    ADCON0bits.ADCONT = 0;    
+
+    // Start the conversion
+    ADCON0bits.ADGO = 1;
+
+
+    // Wait for the conversion to finish
+    while (ADCON0bits.ADGO)
+    {
+    }
+    
+    
+    // Conversion finished, return the result
+    return ((adc_result_t)((ADRESH << 8) + ADRESL));
+}
+
+void ADCC_StopConversion(void)
+{
+    //Reset the ADGO bit.
+    ADCON0bits.ADGO = 0;
+}
+
+void ADCC_SetStopOnInterrupt(void)
+{
+    //Set the ADSOI bit.
+    ADCON3bits.ADSOI = 1;
+}
+
+void ADCC_DischargeSampleCapacitor(void)
+{
+    //Set the ADC channel to AVss.
+    ADPCH = 0x3C;   
+}
+
+void ADCC_LoadAcquisitionRegister(uint16_t acquisitionValue)
+{
+    //Load the ADACQH and ADACQL registers.
+    ADACQH = acquisitionValue >> 8; 
+    ADACQL = acquisitionValue;  
+}
+
+void ADCC_SetPrechargeTime(uint16_t prechargeTime)
+{
+    //Load the ADPREH and ADPREL registers.
+    ADPREH = prechargeTime >> 8;  
+    ADPREL = prechargeTime;
+}
+
+void ADCC_SetRepeatCount(uint8_t repeatCount)
+{
+    //Load the ADRPT register.
+    ADRPT = repeatCount;   
+}
+
+uint8_t ADCC_GetCurrentCountofConversions(void)
+{
+    //Return the contents of ADCNT register
+    return ADCNT;
+}
+
+void ADCC_ClearAccumulator(void)
+{
+    //Reset the ADCON2bits.ADACLR bit.
+    ADCON2bits.ADACLR = 1;
+}
+
+int24_t ADCC_GetAccumulatorValue(void)
+{
+    //Return the contents of ADACCU, ADACCH and ADACCL registers
+    return (((int24_t)ADACCU << 16)+((int24_t)ADACCH << 8) + ADACCL);
+}
+
+bool ADCC_HasAccumulatorOverflowed(void)
+{
+    //Return the status of ADSTATbits.ADAOV
+    return ADSTATbits.ADAOV;
+}
+
+uint16_t ADCC_GetFilterValue(void)
+{
+    //Return the contents of ADFLTRH and ADFLTRL registers
+    return ((uint16_t)((ADFLTRH << 8) + ADFLTRL));
+}
+
+uint16_t ADCC_GetPreviousResult(void)
+{
+    //Return the contents of ADPREVH and ADPREVL registers
+    return ((uint16_t)((ADPREVH << 8) + ADPREVL));
+}
+
+void ADCC_DefineSetPoint(uint16_t setPoint)
+{
+    //Sets the ADSTPTH and ADSTPTL registers
+    ADSTPTH = setPoint >> 8;
+    ADSTPTL = setPoint;
+}
+
+void ADCC_SetUpperThreshold(uint16_t upperThreshold)
+{
+    //Sets the ADUTHH and ADUTHL registers
+    ADUTHH = upperThreshold >> 8;
+    ADUTHL = upperThreshold;
+}
+
+void ADCC_SetLowerThreshold(uint16_t lowerThreshold)
+{
+    //Sets the ADLTHH and ADLTHL registers
+    ADLTHH = lowerThreshold >> 8;
+    ADLTHL = lowerThreshold;
+}
+
+uint16_t ADCC_GetErrorCalculation(void)
+{
+	//Return the contents of ADERRH and ADERRL registers
+	return ((uint16_t)((ADERRH << 8) + ADERRL));
+}
+
+void ADCC_EnableDoubleSampling(void)
+{
+    //Sets the ADCON1bits.ADDSEN
+    ADCON1bits.ADDSEN = 1;
+}
+
+void ADCC_EnableContinuousConversion(void)
+{
+    //Sets the ADCON0bits.ADCONT
+    ADCON0bits.ADCONT = 1;
+}
+
+void ADCC_DisableContinuousConversion(void)
+{
+    //Resets the ADCON0bits.ADCONT
+    ADCON0bits.ADCONT = 0;
+}
+
+bool ADCC_HasErrorCrossedUpperThreshold(void)
+{
+    //Returns the value of ADSTATbits.ADUTHR bit.
+    return ADSTATbits.ADUTHR;
+}
+
+bool ADCC_HasErrorCrossedLowerThreshold(void)
+{
+    //Returns the value of ADSTATbits.ADLTHR bit.
+    return ADSTATbits.ADLTHR;
+}
+
+uint8_t ADCC_GetConversionStageStatus(void)
+{
+    //Returns the contents of ADSTATbits.ADSTAT field.
+    return ADSTATbits.ADSTAT;
+}
+
+
+/**
+ End of File
+*/

--- a/grandpapa_board.X/mcc_generated_files/adcc.h
+++ b/grandpapa_board.X/mcc_generated_files/adcc.h
@@ -1,0 +1,779 @@
+/**
+  ADCC Generated Driver API Header File
+
+  @Company
+    Microchip Technology Inc.
+
+  @File Name
+    adcc.h
+
+  @Summary
+    This is the generated header file for the ADCC driver using PIC10 / PIC12 / PIC16 / PIC18 MCUs 
+
+  @Description
+    This header file provides APIs for driver for ADCC.
+    Generation Information :
+        Product Revision  :  PIC10 / PIC12 / PIC16 / PIC18 MCUs - 1.65.2
+        Device            :  PIC18F26K83
+        Driver Version    :  2.01
+    The generated drivers are tested against the following:
+        Compiler          :  XC8 1.45
+        MPLAB             :  MPLAB X 4.15
+*/
+
+/*
+    (c) 2018 Microchip Technology Inc. and its subsidiaries. 
+    
+    Subject to your compliance with these terms, you may use Microchip software and any 
+    derivatives exclusively with Microchip products. It is your responsibility to comply with third party 
+    license terms applicable to your use of third party software (including open source software) that 
+    may accompany Microchip software.
+    
+    THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES, WHETHER 
+    EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE, INCLUDING ANY 
+    IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY, AND FITNESS 
+    FOR A PARTICULAR PURPOSE.
+    
+    IN NO EVENT WILL MICROCHIP BE LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, 
+    INCIDENTAL OR CONSEQUENTIAL LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND 
+    WHATSOEVER RELATED TO THE SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP 
+    HAS BEEN ADVISED OF THE POSSIBILITY OR THE DAMAGES ARE FORESEEABLE. TO 
+    THE FULLEST EXTENT ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL 
+    CLAIMS IN ANY WAY RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT 
+    OF FEES, IF ANY, THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS 
+    SOFTWARE.
+*/
+
+#ifndef ADCC_H
+#define ADCC_H
+
+/**
+  Section: Included Files
+*/
+
+#include <xc.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus  // Provide C++ Compatibility
+
+    extern "C" {
+
+#endif
+
+/**
+  Section: Data Types Definitions
+*/
+
+/**
+ *  result size of an A/D conversion
+ */
+
+typedef uint16_t adc_result_t;
+#ifndef int24_t
+typedef signed short long int int24_t;
+#endif
+
+/** ADC Channel Definition
+
+ @Summary
+   Defines the channels available for conversion.
+
+ @Description
+   This routine defines the channels that are available for the module to use.
+
+ Remarks:
+   None
+ */
+
+typedef enum {
+    channel_BATT_CURR = 0x2,
+    channel_BATT_VOLT = 0x3,
+    channel_AUX_CURR  = 0x4
+} adcc_channel_t; //page 677
+
+/**
+  Section: ADC Module APIs
+*/
+
+/**
+  @Summary
+    Initializes the ADCC
+
+  @Description
+    This routine initializes the Initializes the ADCC.
+    This routine must be called before any other ADCC routine is called.
+    This routine should only be called once during system initialization.
+
+  @Preconditions
+    None
+
+  @Param
+    None
+
+  @Returns
+    None
+
+  @Comment
+    
+
+  @Example
+    <code>
+    uint16_t convertedValue;    
+
+    ADCC_Initialize();
+    convertedValue = ADCC_GetSingleConversion(AN1_Channel);
+    </code>
+*/
+void ADCC_Initialize(void);
+
+/**
+  @Summary
+     Allows selection of a channel for conversion
+
+  @Description
+    This routine is used to select desired channel for conversion.
+    available
+    
+  @Preconditions
+    ADCC_Initialize() function should have been called before calling this function.
+
+  @Returns
+    None
+
+  @Param
+    Pass in required channel number
+    "For available channel refer to enum under adcc.h file"
+
+  @Example
+    <code>
+    uint16_t convertedValue; 
+
+    ADCC_Initialize();   
+    ADCC_StartConversion(AN1_Channel);
+    convertedValue = ADCC_GetConversionResult();
+    </code>
+*/
+void ADCC_StartConversion(adcc_channel_t channel);
+
+/**
+  @Summary
+    Returns true when the conversion is completed otherwise false.
+
+  @Description
+    This routine is used to determine if conversion is completed.
+    When conversion is complete routine returns true. It returns false otherwise.
+
+  @Preconditions
+    ADCC_Initialize() and ADCC_StartConversion(adcc_channel_t channel)
+    function should have been called before calling this function.
+
+  @Returns
+    true  - If conversion is complete
+    false - If conversion is not completed
+
+  @Param
+    None
+
+  @Example
+    <code>
+    uint16_t convertedValue;    
+
+    ADCC_Initialize();    
+    ADCC_StartConversion(AN1_Channel);
+    while(!ADCC_IsConversionDone());
+    convertedValue = ADCC_GetConversionResult();
+    </code>
+ */
+bool ADCC_IsConversionDone();
+
+/**
+  @Summary
+    Returns the ADCC conversion value.
+
+  @Description
+    This routine is used to get the analog to digital converted value. This
+    routine gets converted values from the channel specified.
+
+  @Preconditions
+    This routine returns the conversion value only after the conversion is complete.
+    Completion status can be checked using
+    ADCC_IsConversionDone() routine.
+
+  @Returns
+    Returns the converted value.
+
+  @Param
+    None
+
+  @Example
+    <code>
+    uint16_t convertedValue;    
+
+    ADCC_Initialize();    
+    ADCC_StartConversion(AN1_Channel);
+    while(!ADCC_IsConversionDone());
+    convertedValue = ADCC_GetConversionResult();
+    </code>
+ */
+adc_result_t ADCC_GetConversionResult(void);
+
+/**
+  @Summary
+    Returns the ADCC conversion value
+    also allows selection of a channel for conversion.
+
+  @Description
+    This routine is used to select desired channel for conversion
+    and to get the analog to digital converted value after a single conversion.
+
+  @Preconditions
+    ADCC_Initialize() and ADCC_DisableContinuousConversion() functions should have been called before calling this function.
+
+  @Returns
+    Returns the converted value.
+
+  @Param
+    Pass in required channel number.
+    "For available channel refer to enum under adcc.h file"
+
+  @Example
+    <code>
+    uint16_t convertedValue;
+
+    ADCC_Initialize();
+    ADCC_DisableContinuousConversion();
+	
+    convertedValue = ADCC_GetSingleConversion(AN1_Channel);
+    </code>
+*/
+adc_result_t ADCC_GetSingleConversion(adcc_channel_t channel);
+
+/**
+  @Summary
+    Stops the ADCC conversion by resetting the ADGO bit.
+
+  @Description
+    None
+
+  @Preconditions
+    ADCC_Initialize() and ADCC_StartConversion() functions should have been called before calling this function.
+
+  @Returns
+    None
+
+  @Param
+    None
+
+  @Example
+    <code>
+    ADCC_Initialize();
+	ADCC_StartConversion(AN1_Channel);
+	ADCC_StopConversion();
+    </code>
+*/
+void ADCC_StopConversion(void);
+
+/**
+  @Summary
+    Stops the ADCC from automatic retriggering in continuous sampling mode
+
+  @Description
+    None
+
+  @Preconditions
+    ADCC_Initialize() and ADCC_EnableContinuousConversion() functions should have been called before calling this function.
+
+  @Returns
+    None
+
+  @Param
+    None
+
+  @Example
+    <code>
+        ADCC_Initialize();
+	ADCC_EnableContinuousConversion();	
+    </code>
+*/
+void ADCC_SetStopOnInterrupt(void);
+
+/**
+  @Summary
+    Discharges the input sample capacitor by setting the channel to AVss.
+
+  @Description
+    None
+
+  @Preconditions
+    None.
+
+  @Returns
+    None
+
+  @Param
+    None
+
+  @Example
+    <code>
+    </code>
+*/
+void ADCC_DischargeSampleCapacitor(void); 
+
+/**
+  @Summary
+    Loads the ADACQ register by the 8 bit value sent as argument.
+
+  @Description
+    None
+
+  @Preconditions
+    None.
+
+  @Returns
+    None
+
+  @Param
+    8 bit value to be set in the acquisition register.
+
+  @Example
+    <code>
+        uint16_t acquisitionValue = 98;
+	ADCC_LoadAcquisitionRegister(acquisitionValue);
+    </code>
+*/
+void ADCC_LoadAcquisitionRegister(uint16_t);
+/**
+  @Summary
+    Loads the ADPRE register by the 8 bit value sent as argument.
+
+  @Description
+    None
+
+  @Preconditions
+    None.
+
+  @Returns
+    None
+
+  @Param
+    8 bit value to be set in the precharge register.
+
+  @Example
+    <code>
+        uint16_t prechargeTime = 98;
+	ADCC_SetPrechargeTime(prechargeTime);
+    </code>
+*/
+void ADCC_SetPrechargeTime(uint16_t);
+
+/**
+  @Summary
+    Loads the ADRPT register by the 8 bit value sent as argument.
+
+  @Description
+    None
+
+  @Preconditions
+    None.
+
+  @Returns
+    None
+
+  @Param
+    8 bit value to be set in the Repeat register.
+
+  @Example
+    <code>
+	uint8_t repeat = 98;
+	ADCC_SetRepeatCount(repeat);
+    </code>
+*/
+void ADCC_SetRepeatCount(uint8_t);
+
+/**
+  @Summary
+    Returns the ADCNT register contents.
+
+  @Description
+    None
+
+  @Preconditions
+    None.
+
+  @Returns
+    Contents of ADCNT register
+
+  @Param
+    None.
+
+  @Example
+    <code>
+	uint8_t count = ADCC_GetCurrentCountofConversions();
+	
+    </code>
+*/
+uint8_t ADCC_GetCurrentCountofConversions(void);
+
+/**
+  @Summary
+    Clears the ADACLR bit.
+
+  @Description
+    None
+
+  @Preconditions
+    None.
+
+  @Returns
+    None
+
+  @Param
+    None.
+
+  @Example
+    <code>
+	ADCC_ClearAccumulator();
+	
+    </code>
+*/
+void ADCC_ClearAccumulator(void);
+
+/**
+  @Summary
+   Returns the value obtained from ADACCU, ADACCH and ADACCL registers.
+
+  @Description
+    None
+
+  @Preconditions
+    None.
+
+  @Returns
+    Value obtained from ADACCU, ADACCH and ADACCL registers.
+
+  @Param
+    None.
+
+  @Example
+    <code>
+        uint32_t accumulatorValue = ADCC_GetAccumulatorValue();
+    </code>
+*/
+int24_t ADCC_GetAccumulatorValue(void);
+
+/**
+  @Summary
+   Returns the contents of ADAOV setting.
+
+  @Description
+    None
+
+  @Preconditions
+    None.
+
+  @Returns
+    Value of ADAOV bit.
+
+  @Param
+    None.
+
+  @Example
+    <code>
+	bool accumulatorOverflow = ADCC_HasAccumulatorOverflowed();
+	
+    </code>
+*/
+bool ADCC_HasAccumulatorOverflowed(void);
+
+/**
+  @Summary
+   Returns the contents of ADFLTRH and ADFLTRL registers.
+
+  @Description
+    None
+
+  @Preconditions
+    None.
+
+  @Returns
+    16 bit value obtained from ADFLTRH and ADFLTRL registers.
+
+  @Param
+    None.
+
+  @Example
+    <code>
+	uint16_t filterValue = ADCC_GetFilterValue();
+	
+    </code>
+*/
+uint16_t ADCC_GetFilterValue(void);
+
+/**
+  @Summary
+   Returns the contents of ADPREVH and ADPREVL registers.
+
+  @Description
+    None
+
+  @Preconditions
+    None.
+
+  @Returns
+    16 bit value obtained from ADPREVH and ADPREVL registers.
+
+  @Param
+    None.
+
+  @Example
+    <code>
+	uint16_t prevResult = ADCC_GetPreviousResult();
+	
+    </code>
+*/
+uint16_t ADCC_GetPreviousResult(void);
+
+/**
+  @Summary
+   Sets the ADSTPTH and ADSTPTL registers.
+
+  @Description
+    None
+
+  @Preconditions
+    None
+
+  @Returns
+    None
+
+  @Param
+    16 bit value for set point.
+
+  @Example
+    <code>
+	uint16_t setPoint = 90;
+	ADCC_DefineSetPoint(setPoint);
+    </code>
+*/
+void ADCC_DefineSetPoint(uint16_t);
+
+/**
+  @Summary
+   Sets the ADUTHH and ADUTHL register.
+
+  @Description
+    None
+
+  @Preconditions
+    None
+
+  @Returns
+    None
+
+  @Param
+    16 bit value for upper threshold.
+
+  @Example
+    <code>
+	uint16_t upperThreshold = 90;
+	ADCC_SetUpperThreshold(upperThreshold);
+	
+    </code>
+*/
+void ADCC_SetUpperThreshold(uint16_t);
+
+/**
+  @Summary
+   Sets the ADLTHH and ADLTHL register.
+
+  @Description
+    None
+
+  @Preconditions
+    None
+
+  @Returns
+    None
+
+  @Param
+    16 bit value for lower threshold..
+
+  @Example
+    <code>
+	uint16_t lowerThreshold = 90;
+	ADCC_SetLowerThreshold(lowerThreshold);
+	
+    </code>
+*/
+void ADCC_SetLowerThreshold(uint16_t);
+
+/**
+  @Summary
+   Returns the 16 bit value obtained from ADERRH and ADERRL registers.
+
+  @Description
+    None
+
+  @Preconditions
+    None
+
+  @Returns
+    16 bit value obtained from ADERRH and ADERRL registers.
+
+  @Param
+    None.
+
+  @Example
+    <code>
+	uint16_t error = ADCC_GetErrorCalculation(void);
+    </code>
+*/
+uint16_t ADCC_GetErrorCalculation(void);
+
+/**
+  @Summary
+   Sets the ADDSEN bit.
+
+  @Description
+    None
+
+  @Preconditions
+    None
+
+  @Returns
+    None
+
+  @Param
+    None.
+
+  @Example
+    <code>
+    </code>
+*/
+void ADCC_EnableDoubleSampling(void);
+
+/**
+  @Summary
+   Sets the ADCONT bit.
+
+  @Description
+    None
+
+  @Preconditions
+    None
+
+  @Returns
+    None
+
+  @Param
+    None.
+
+  @Example
+    <code>
+    </code>
+*/
+void ADCC_EnableContinuousConversion(void);
+
+/**
+  @Summary
+   Resets the ADCONT bit.
+
+  @Description
+    None
+
+  @Preconditions
+    None
+
+  @Returns
+    None
+
+  @Param
+    None.
+
+  @Example
+    <code>
+    </code>
+*/
+void ADCC_DisableContinuousConversion(void);
+
+/**
+  @Summary
+   Returns the value of ADUTHR bit.
+
+  @Description
+    None
+
+  @Preconditions
+    None
+
+  @Returns
+    Returns the value of ADUTHR bit.
+
+  @Param
+    None.
+
+  @Example
+    <code>
+    </code>
+*/
+bool ADCC_HasErrorCrossedUpperThreshold(void);
+
+/**
+  @Summary
+   Returns the value of ADLTHR bit.
+
+  @Description
+    None
+
+  @Preconditions
+    None
+
+  @Returns
+    Returns the value of ADLTHR bit.
+
+  @Param
+    None.
+
+  @Example
+    <code>
+    </code>
+*/
+bool ADCC_HasErrorCrossedLowerThreshold(void);
+
+/**
+  @Summary
+   Returns value of ADSTAT setting.
+
+  @Description
+    None
+
+  @Preconditions
+    None
+
+  @Returns
+    Returns value of ADSTAT setting.
+
+  @Param
+    None.
+
+  @Example
+    <code>
+    </code>
+*/
+uint8_t ADCC_GetConversionStageStatus(void);
+
+
+
+
+#ifdef __cplusplus  // Provide C++ Compatibility
+
+    }
+
+#endif
+
+#endif	//ADCC_H
+/**
+ End of File
+*/
+

--- a/grandpapa_board.X/mcc_generated_files/fvr.c
+++ b/grandpapa_board.X/mcc_generated_files/fvr.c
@@ -1,0 +1,71 @@
+/**
+  FVR Generated Driver File
+
+  @Company
+    Microchip Technology Inc.
+
+  @File Name
+    fvr.c
+
+  @Summary
+    This is the generated driver implementation file for the FVR driver using PIC10 / PIC12 / PIC16 / PIC18 MCUs
+
+  @Description
+    This source file provides APIs for FVR.
+    Generation Information :
+        Product Revision  :  PIC10 / PIC12 / PIC16 / PIC18 MCUs - 1.65.2
+        Device            :  PIC18F26K83
+        Driver Version    :  2.01
+    The generated drivers are tested against the following:
+        Compiler          :  XC8 1.45
+        MPLAB             :  MPLAB X 4.15
+*/
+
+/*
+    (c) 2018 Microchip Technology Inc. and its subsidiaries. 
+    
+    Subject to your compliance with these terms, you may use Microchip software and any 
+    derivatives exclusively with Microchip products. It is your responsibility to comply with third party 
+    license terms applicable to your use of third party software (including open source software) that 
+    may accompany Microchip software.
+    
+    THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES, WHETHER 
+    EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE, INCLUDING ANY 
+    IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY, AND FITNESS 
+    FOR A PARTICULAR PURPOSE.
+    
+    IN NO EVENT WILL MICROCHIP BE LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, 
+    INCIDENTAL OR CONSEQUENTIAL LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND 
+    WHATSOEVER RELATED TO THE SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP 
+    HAS BEEN ADVISED OF THE POSSIBILITY OR THE DAMAGES ARE FORESEEABLE. TO 
+    THE FULLEST EXTENT ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL 
+    CLAIMS IN ANY WAY RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT 
+    OF FEES, IF ANY, THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS 
+    SOFTWARE.
+*/
+
+/**
+  Section: Included Files
+*/
+
+#include <xc.h>
+#include "fvr.h"
+
+/**
+  Section: FVR APIs
+*/
+
+void FVR_Initialize(void)
+{
+    // CDAFVR off; FVREN enabled; TSRNG Lo_range; ADFVR 4x; TSEN disabled; 
+    FVRCON = 0x83;
+}
+
+bool FVR_IsOutputReady(void)
+{
+    return (FVRCONbits.FVRRDY);
+}
+/**
+ End of File
+*/
+

--- a/grandpapa_board.X/mcc_generated_files/fvr.h
+++ b/grandpapa_board.X/mcc_generated_files/fvr.h
@@ -1,0 +1,139 @@
+/**
+  FVR Generated Driver API Header File
+
+  @Company
+    Microchip Technology Inc.
+
+  @File Name
+    fvr.h
+
+  @Summary
+    This is the generated header file for the FVR driver using PIC10 / PIC12 / PIC16 / PIC18 MCUs
+
+  @Description
+    This header file provides APIs for driver for FVR.
+    Generation Information :
+        Product Revision  :  PIC10 / PIC12 / PIC16 / PIC18 MCUs - 1.65.2
+        Device            :  PIC18F26K83
+        Driver Version    :  2.01
+    The generated drivers are tested against the following:
+        Compiler          :  XC8 1.45
+        MPLAB 	          :  MPLAB X 4.15
+*/
+
+/*
+    (c) 2018 Microchip Technology Inc. and its subsidiaries. 
+    
+    Subject to your compliance with these terms, you may use Microchip software and any 
+    derivatives exclusively with Microchip products. It is your responsibility to comply with third party 
+    license terms applicable to your use of third party software (including open source software) that 
+    may accompany Microchip software.
+    
+    THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES, WHETHER 
+    EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE, INCLUDING ANY 
+    IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY, AND FITNESS 
+    FOR A PARTICULAR PURPOSE.
+    
+    IN NO EVENT WILL MICROCHIP BE LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, 
+    INCIDENTAL OR CONSEQUENTIAL LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND 
+    WHATSOEVER RELATED TO THE SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP 
+    HAS BEEN ADVISED OF THE POSSIBILITY OR THE DAMAGES ARE FORESEEABLE. TO 
+    THE FULLEST EXTENT ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL 
+    CLAIMS IN ANY WAY RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT 
+    OF FEES, IF ANY, THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS 
+    SOFTWARE.
+*/
+
+#ifndef FVR_H
+#define FVR_H
+
+/**
+  Section: Included Files
+*/
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus  // Provide C++ Compatibility
+
+    extern "C" {
+
+#endif
+
+/**
+  Section: FVR APIs
+*/
+
+/**
+  @Summary
+    Initializes the FVR
+
+  @Description
+    This routine initializes the FVR.
+    This routine must be called before any other FVR routine is called.
+    This routine should only be called once during system initialization.
+
+  @Preconditions
+    None
+
+  @Param
+    None
+
+  @Returns
+    None
+
+  @Comment
+    
+
+  @Example
+    <code>
+    FVR_Initialize();
+    </code>
+*/
+ void FVR_Initialize(void);
+
+/**
+  @Summary
+    Gets the FVR output ready status.
+
+  @Description
+    This routine gets the FVR output ready status.
+
+  @Preconditions
+    The FVR_Initialize() routine should be called
+    prior to use this routine.
+
+  @Param
+    None
+
+  @Returns
+     true  - FVR module is ready for use.
+     false - FVR module is not ready for use.
+
+  @Example
+    <code>
+    FVR_Initialize();
+
+    if(FVR_IsOutputReady())
+    {
+          //user code
+    }
+    else
+    {
+          //user code
+    }
+    </code>
+*/
+bool FVR_IsOutputReady(void);
+
+#ifdef __cplusplus  // Provide C++ Compatibility
+
+    }
+
+#endif
+
+#endif // FVR_H
+/**
+ End of File
+*/
+

--- a/grandpapa_board.X/nbproject/configurations.xml
+++ b/grandpapa_board.X/nbproject/configurations.xml
@@ -28,6 +28,8 @@
                    displayName="Header Files"
                    projectFiles="true">
       <itemPath>interrupt_manager.h</itemPath>
+      <itemPath>mcc_generated_files/adcc.h</itemPath>
+      <itemPath>mcc_generated_files/fvr.h</itemPath>
     </logicalFolder>
     <logicalFolder name="LinkerScript"
                    displayName="Linker Files"
@@ -41,6 +43,8 @@
       <itemPath>spi_shit.c</itemPath>
       <itemPath>spi_shit.h</itemPath>
       <itemPath>config_registers.c</itemPath>
+      <itemPath>mcc_generated_files/adcc.c</itemPath>
+      <itemPath>mcc_generated_files/fvr.c</itemPath>
     </logicalFolder>
     <logicalFolder name="ExternalFiles"
                    displayName="Important Files"

--- a/grandpapa_board.X/nbproject/configurations.xml
+++ b/grandpapa_board.X/nbproject/configurations.xml
@@ -63,10 +63,10 @@
         <targetDevice>PIC18F26K83</targetDevice>
         <targetHeader></targetHeader>
         <targetPluginBoard></targetPluginBoard>
-        <platformTool>PICkit3PlatformTool</platformTool>
+        <platformTool>noID</platformTool>
         <languageToolchain>XC8</languageToolchain>
-        <languageToolchainVersion>2.36</languageToolchainVersion>
-        <platform>3</platform>
+        <languageToolchainVersion>2.41</languageToolchainVersion>
+        <platform>4</platform>
       </toolsSet>
       <packs>
         <pack name="PIC18F-K_DFP" vendor="Microchip" version="1.5.114"/>
@@ -169,7 +169,7 @@
         <property key="input-libraries" value="libm"/>
         <property key="keep-generated-startup.as" value="false"/>
         <property key="link-in-c-library" value="true"/>
-        <property key="link-in-c-library-gcc" value=""/>
+        <property key="link-in-c-library-gcc" value="-mc90lib"/>
         <property key="link-in-peripheral-library" value="false"/>
         <property key="managed-stack" value="false"/>
         <property key="opt-xc8-linker-file" value="false"/>
@@ -188,7 +188,6 @@
         <property key="debugoptions.debug-startup" value="Use system settings"/>
         <property key="debugoptions.reset-behaviour" value="Use system settings"/>
         <property key="debugoptions.useswbreakpoints" value="false"/>
-        <property key="firmware.download.all" value="false"/>
         <property key="hwtoolclock.frcindebug" value="false"/>
         <property key="memories.aux" value="false"/>
         <property key="memories.bootflash" value="true"/>
@@ -274,12 +273,15 @@
       </XC8-CO>
       <XC8-config-global>
         <property key="advanced-elf" value="true"/>
+        <property key="constdata-progmem" value="true"/>
         <property key="gcc-opt-driver-new" value="true"/>
         <property key="gcc-opt-std" value="-std=c99"/>
         <property key="gcc-output-file-format" value="dwarf-3"/>
+        <property key="mapped-progmem" value="false"/>
         <property key="omit-pack-options" value="false"/>
         <property key="omit-pack-options-new" value="1"/>
         <property key="output-file-format" value="-mcof,+elf"/>
+        <property key="smart-io-format" value=""/>
         <property key="stack-size-high" value="auto"/>
         <property key="stack-size-low" value="auto"/>
         <property key="stack-size-main" value="auto"/>

--- a/grandpapa_board.X/spi_shit.c
+++ b/grandpapa_board.X/spi_shit.c
@@ -40,4 +40,12 @@ void spi_init(){
      RC2PPS = 0b011111; //Set pin C2 as SDO (MOSI)
      RC3PPS = 0b011110; //Set pin C3 as SCK
      SPI1SDIPPS = 0b10100; //Set pin C4 as SDI (MISO)
+
+    //  these don't belong here but i need to define somewhere
+    TRISA2 = 1;
+    TRISA3 = 1;
+    TRISA4 = 1;
+    ANSELA2 = 1;
+    ANSELA3 = 1;
+    ANSELA4 = 1;
 }


### PR DESCRIPTION
Very crude solution but it gets the job done. Adcc and Fvr are mcc_generated_files, but the parts I can explain:
- the adc source clock is fosc with a conversion clock (?) at FOSC/100
  - for the ```on-the-pad-charging``` board, this value had to change to allow adc to provide an accurate reading
- the sensor_id values need to change but I don't know what we want them to be (BATT_VOLT = ?, AUX_CUR = BUS_CURR?)

Testing:
Turned off external power, sensor_mag_2 (aux_cur) turned off but the battery was still powering everything so parsley time message continued
![image](https://user-images.githubusercontent.com/56371758/227755459-04d0dc10-c450-4168-be4c-0df61f73ae42.png)

sensor_mag_1 (batt_volt) started at 4095 mV and by the time the testing finished (~5min), it dropped to 3756 mV, not sure if this is normal behaviour or requires further testing?
 